### PR TITLE
Automatische Steuerung Hotend Lüfter

### DIFF
--- a/_configuration/configuration.md
+++ b/_configuration/configuration.md
@@ -41,7 +41,7 @@ If you've never configured and calibrated a 3D Printer before, here are some goo
 
 - [Calibration](//reprap.org/wiki/Calibration)
 - [Calibrating Steps-per-unit](//youtu.be/wAL9d7FgInk)
-- [Prusa's calculators](//calculator.josefprusa.cz)
+- [Prusa's calculators](//blog.prusaprinters.org/calculator_3416/)
 - [Triffid Hunter's Calibration Guide](//reprap.org/wiki/Triffid_Hunter%27s_Calibration_Guide)
 - [The Essential Calibration Set](//www.thingiverse.com/thing:5573)
 - [Calibration of your RepRap](//sites.google.com/site/repraplogphase/calibration-of-your-reprap)

--- a/_gcode/G060.md
+++ b/_gcode/G060.md
@@ -3,7 +3,7 @@ tag: g060
 title: Save Current Position
 brief: Save current position to specified slot
 author: shitcreek
-contrib: Hans007a
+contrib: [ Hans007a, TwoRedCells ]
 codes: [ G60 ]
 related: [ G61 ]
 
@@ -21,4 +21,4 @@ example:
       - G60 S1 ; Save current position to slot 1
 ---
 
-Save current position to the specified slot. Default slot is 0. Total available slots, `SAVED_POSITIONS`, is set `Configuration_adv.h`. Default slot is 0. Use [`G0`](/docs/gcode/G000-G001.html) or [`G1`](/docs/gcode/G000-G001.html) with the R0, R1 or R2 parameter to move the current tool to a saved position.
+Save current position to the specified slot (defaults to 0 if unspecified). Total available slots, `SAVED_POSITIONS`, is set in `Configuration_adv.h`. Use [`G061`](/docs/gcode/G0061.html) to move the current tool to a saved position.

--- a/_gcode/M043-T.md
+++ b/_gcode/M043-T.md
@@ -3,7 +3,7 @@ tag: m0043b
 title: Toggle Pins
 brief: Get information about pins.
 author: thinkyhead
-
+contrib: [ TwoRedCells ]
 experimental: true
 requires: PINS_DEBUGGING
 group: debug
@@ -53,14 +53,6 @@ parameters:
     values:
       -
         tag: time
-        type: int
-  -
-    tag: S
-    optional: true
-    description: Perform a Z-servo probe test on the servo with the specified index.
-    values:
-      -
-        tag: index
         type: int
 
 examples:

--- a/_gcode/M149.md
+++ b/_gcode/M149.md
@@ -4,6 +4,7 @@ title: Set Temperature Units
 brief: Set temperature units to Celsius, Fahrenheit, or Kelvin.
 author: thinkyhead
 
+requires: TEMPERATURE_UNITS_SUPPORT
 group: units
 
 codes: [ M149 ]

--- a/_gcode/M217.md
+++ b/_gcode/M217.md
@@ -23,13 +23,21 @@ parameters:
         tag: linear
         type: float
   -
-    tag: R
+    tag: B
     optional: true
-    description: Retract feedrate
+    description: Extra resume
     values:
       -
-        tag: feedrate
-        type: int
+        tag: linear
+        type: float
+  -
+    tag: E
+    optional: true
+    description: Extra Prime Length
+    values:
+      -
+        tag: linear
+        type: float
   -
     tag: P
     optional: true
@@ -38,11 +46,66 @@ parameters:
       -
         tag: feedrate
         type: int
-
+  -
+    tag: R
+    optional: true
+    description: Retract feedrate
+    values:
+      -
+        tag: feedrate
+        type: int
+  -
+    tag: U
+    optional: true
+    description: Unretract feedrate
+    values:
+      -
+        tag: linear
+        type: int
+  -
+    tag: F
+    optional: true
+    description: Fan speed (0-255)
+    values:
+      -
+        tag: linear
+        type: int
+  -
+    tag: G
+    optional: true
+    description: Fan Time (seconds)
+    values:
+      -
+        tag: linear
+        type: int
+  -
+    tag: A
+    optional: true
+    description: Migration Auto Mode. Requires `TOOLCHANGE_MIGRATION_FEATURE`.
+    values:
+      -
+        tag: linear
+        type: int
+  -
+    tag: L
+    optional: true
+    description: Last Migration. Requires `TOOLCHANGE_MIGRATION_FEATURE`.
+    values:
+      -
+        tag: linear
+        type: int
+  -
+    tag: W
+    optional: true
+    description: Enable Park Feature. Requires `TOOLCHANGE_PARK` - was `SINGLENOZZLE_SWAP_PARK`.
+    values:
+      -
+        tag: linear
+        type: int
   -
     tag: X
     optional: true
-    description: Park X position. Requires `SINGLENOZZLE_SWAP_PARK`.
+    description: Park X position. Requires `TOOLCHANGE_PARK` - was `SINGLENOZZLE_SWAP_PARK`.
     values:
       -
         tag: linear
@@ -51,12 +114,20 @@ parameters:
   -
     tag: Y
     optional: true
-    description: Park Y position. Requires `SINGLENOZZLE_SWAP_PARK`.
+    description: Park Y position. Requires `TOOLCHANGE_PARK` - was `SINGLENOZZLE_SWAP_PARK`.
     values:
       -
         tag: linear
         type: float
 
+  -
+    tag: Y
+    optional: true
+    description: Enable First Prime on uninitialized Nozzles. Requires `TOOLCHANGE_FS_PRIME_FIRST_USED`.
+    values:
+      -
+        tag: linear
+        type: int
   -
     tag: Z
     optional: true

--- a/_gcode/M300.md
+++ b/_gcode/M300.md
@@ -17,7 +17,7 @@ parameters:
   -
     tag: P
     optional: true
-    description: Duration (1s)
+    description: Duration (1ms)
     values:
       -
         tag: ms

--- a/_tools/lin_advance/k-factor.js
+++ b/_tools/lin_advance/k-factor.js
@@ -190,12 +190,12 @@ function genGcode() {
                   ';\n' +
                   'G21 ; Millimeter units\n' +
                   'G90 ; Absolute XYZ\n' +
-                  'M83 ; Relative E\n' +  
+                  'M83 ; Relative E\n' +
                   'T' + TOOL_INDEX + ' ; Switch to tool ' + TOOL_INDEX + '\n' +
-                  'G1 Z5 F100 ; Z raise\n' +
                   'M104 S' + NOZZLE_TEMP + ' ; Set nozzle temperature (no wait)\n' +
                   'M190 S' + BED_TEMP + ' ; Set bed temperature (wait)\n' +
                   'G28 ; Home all axes\n' +
+                  'G1 Z5 F100 ; Z raise\n' +
                   'M109 S' + NOZZLE_TEMP + ' ; Wait for nozzle temp\n' +
                   (BED_LEVELING !== '0' ? BED_LEVELING + '; Activate bed leveling compensation\n' : '') +
                   'M204 P' + ACCELERATION + ' ; Acceleration\n' +


### PR DESCRIPTION
Ich möchte bei meinem Bord creality v4.2.7 den Hotendlüfter bei 50°C einschalten. Meine configuration_adv.h
#define E0_AUTO_FAN_PIN  5
#define E1_AUTO_FAN_PIN -1
#define E2_AUTO_FAN_PIN -1
#define E3_AUTO_FAN_PIN -1
#define E4_AUTO_FAN_PIN -1
#define E5_AUTO_FAN_PIN -1
#define E6_AUTO_FAN_PIN -1
#define E7_AUTO_FAN_PIN -1
#define CHAMBER_AUTO_FAN_PIN -1
#define COOLER_FAN_PIN -1

#define EXTRUDER_AUTO_FAN_TEMPERATURE 50
#define EXTRUDER_AUTO_FAN_SPEED 255   // 255 == full speed
#define CHAMBER_AUTO_FAN_TEMPERATURE 30
#define CHAMBER_AUTO_FAN_SPEED 255
#define COOLER_AUTO_FAN_TEMPERATURE 18
#define COOLER_AUTO_FAN_SPEED 255

funktioniert nicht.
[Marlin.zip](https://github.com/Rhoenpaulus/MarlinDocumentation/files/6254918/Marlin.zip)

